### PR TITLE
Add llmman as a local model provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   ConfiChat offers the flexibility to operate either <em>fully offline</em> or <em>blend offline-and-online</em> capabilities:</p>
 
 <ul style="color: #555; font-size: 20px;">
-  <li><strong>Offline providers</strong> like <a href="https://ollama.com">Ollama</a> and <a href="https://github.com/ggerganov/llama.cpp">LlamaCpp</a> provide privacy by operating on your local machine or network without cloud services.</li>
+  <li><strong>Offline providers</strong> like <a href="https://ollama.com">Ollama</a>, <a href="https://github.com/ggerganov/llama.cpp">LlamaCpp</a> and <a href="https://github.com/llmmanorg/llmman">llmman</a> provide privacy by operating on your local machine or network without cloud services.</li>
   <li><strong>Online providers</strong> like <a href="https://openai.com">OpenAI</a> and <a href="https://anthropic.com">Anthropic</a> offer cutting-edge models via APIs, which have different privacy policies than their chat services, giving you greater control over your data.</li>
 </ul>
 
@@ -65,7 +65,7 @@ In a nutshell, ConfiChat caters to users who value transparent control over thei
 
 - **Cross-Platform Compatibility**: Developed in Flutter, ConfiChat runs on Windows, Linux, Android, MacOS, and iOS
 
-- **Local Model Support (Ollama and LlamaCpp)**: [Ollama](https://ollama.com) & [LlamaCpp](https://github.com/ggerganov/llama.cpp) both offer a range of lightweight, open-source local models, such as [Llama by Meta](https://ai.meta.com/llama/), [Gemma by Google](https://ai.google.dev/gemma), and [Llava](https://github.com/haotian-liu/LLaVA) for multimodal/image support. These models are designed to run efficiently even on machines with limited resources. 
+- **Local Model Support (Ollama, LlamaCpp and llmman)**: [Ollama](https://ollama.com), [LlamaCpp](https://github.com/ggerganov/llama.cpp) & [llmman](https://github.com/llmmanorg/llmman) all offer a range of lightweight, open-source local models, such as [Llama by Meta](https://ai.meta.com/llama/), [Gemma by Google](https://ai.google.dev/gemma), and [Llava](https://github.com/haotian-liu/LLaVA) for multimodal/image support. These models are designed to run efficiently even on machines with limited resources. 
 
 - **OpenAI and Anthropic Support**: Seamlessly integrates with [OpenAI](https://openai.com) and [Anthropic](https://anthropic.com) to provide advanced language model capabilities using your [own API key](https://platform.openai.com/docs/quickstart). Please note that while the API does not store conversations like ChatGPT does, OpenAI retains input data for abuse monitoring purposes. You can review their latest [data retention and security policies](https://openai.com/enterprise-privacy/). In particular, check the "How does OpenAI handle data retention and monitoring for API usage?" in their FAQ (https://openai.com/enterprise-privacy/).
 

--- a/confichat/lib/api_llmman.dart
+++ b/confichat/lib/api_llmman.dart
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2024-25 Rune Berg (http://runeberg.io | https://github.com/1runeberg)
+ * Licensed under Apache 2.0 (https://www.apache.org/licenses/LICENSE-2.0)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import 'package:confichat/api_ollama.dart';
+import 'package:confichat/app_data.dart';
+
+/// llmman (https://github.com/llmmanorg/llmman) is a local model runner that
+/// serves the Ollama API on port 17434, so it reuses the Ollama client as-is.
+class ApiLlmman extends ApiOllama {
+
+  static final ApiLlmman _instance = ApiLlmman._internal();
+  static ApiLlmman get instance => _instance;
+
+  // Factory constructor
+  factory ApiLlmman() {
+    return _instance;
+  }
+
+  ApiLlmman._internal() : super.forProvider(AiProvider.llmman, 17434);
+
+} // ApiLlmman

--- a/confichat/lib/api_ollama.dart
+++ b/confichat/lib/api_ollama.dart
@@ -26,10 +26,15 @@ class ApiOllama extends LlmApi{
     return _instance;
   }
 
-  ApiOllama._internal() : super(AiProvider.ollama) {
+  ApiOllama._internal() : this.forProvider(AiProvider.ollama, 11434);
+
+  // Shared by providers that speak the Ollama API on a different port (e.g. llmman)
+  final int defaultPort;
+
+  ApiOllama.forProvider(super.aiProvider, this.defaultPort) {
       scheme = 'http';
       host = 'localhost';
-      port = 11434; 
+      port = defaultPort; 
       path = '/api';
 
       defaultTemperature = 1.0;
@@ -53,13 +58,13 @@ class ApiOllama extends LlmApi{
       final fileContent = await File(filePath).readAsString();
       final Map<String, dynamic> settings = json.decode(fileContent);
 
-      if (settings.containsKey(AiProvider.ollama.name)) {
+      if (settings.containsKey(aiProvider.name)) {
 
         // Override values in memory from disk
-        scheme = settings[AiProvider.ollama.name]['scheme'] ?? 'http';
-        host = settings[AiProvider.ollama.name]['host'] ?? 'localhost';
-        port = settings[AiProvider.ollama.name]['port'] ?? 11434;
-        path = settings[AiProvider.ollama.name]['path'] ?? '/api';
+        scheme = settings[aiProvider.name]['scheme'] ?? 'http';
+        host = settings[aiProvider.name]['host'] ?? 'localhost';
+        port = settings[aiProvider.name]['port'] ?? defaultPort;
+        path = settings[aiProvider.name]['path'] ?? '/api';
 
       }
     } 
@@ -332,7 +337,7 @@ class ApiOllama extends LlmApi{
 
       } catch (e) {
         final String errorMessage = 'Unable to get chat response: $e\n $responseData';
-        ShowErrorDialog(title: '${AiProvider.ollama.name}: Fatal error' , content: errorMessage);
+        ShowErrorDialog(title: '${aiProvider.name}: Fatal error' , content: errorMessage);
       } 
 
   }

--- a/confichat/lib/app_data.dart
+++ b/confichat/lib/app_data.dart
@@ -71,6 +71,9 @@ class AppData {
       case AiProvider.anthropic:
         api = LlmApiFactory.create(AiProvider.anthropic.name);
         break;
+      case AiProvider.llmman:
+        api = LlmApiFactory.create(AiProvider.llmman.name);
+        break;
       default:
         if (kDebugMode) { print('Unknown AI provider.');  }
     }
@@ -98,7 +101,8 @@ enum AiProvider {
   ollama('Ollama', 0),
   llamacpp('LlamaCpp', 1),
   openai('OpenAI', 2),
-  anthropic('Anthropic', 3);
+  anthropic('Anthropic', 3),
+  llmman('llmman', 4);
 
   final String name;
   final int id;

--- a/confichat/lib/factories.dart
+++ b/confichat/lib/factories.dart
@@ -11,6 +11,7 @@ import 'package:confichat/api_ollama.dart';
 import 'package:confichat/api_llamacpp.dart';
 import 'package:confichat/api_openai.dart';
 import 'package:confichat/api_anthropic.dart';
+import 'package:confichat/api_llmman.dart';
 
 
 class LlmApiFactory {
@@ -24,6 +25,8 @@ class LlmApiFactory {
         return ApiChatGPT();
       case 'anthropic':
         return ApiAnthropic();
+      case 'llmman':
+        return ApiLlmman();
       default:
         throw Exception('Unsupported API provider: $apiProvider');
     }

--- a/confichat/lib/main.dart
+++ b/confichat/lib/main.dart
@@ -112,6 +112,9 @@ class ConfiChat extends StatelessWidget {
             case 'anthropic':
               selectedProvider = AiProvider.anthropic;
               break;
+            case 'llmman':
+              selectedProvider = AiProvider.llmman;
+              break;
             default:
               selectedProvider = AiProvider.ollama; // Fallback to Ollama if the string doesn't match
               break;

--- a/confichat/lib/provider_validator.dart
+++ b/confichat/lib/provider_validator.dart
@@ -8,7 +8,7 @@ import 'package:confichat/app_data.dart';
 import 'package:flutter/foundation.dart';
 
 class ProviderValidator {
-  /// Checks if local providers (Ollama or LlamaCPP) are available
+  /// Checks if local providers (Ollama, LlamaCPP or llmman) are available
   static Future<AiProvider?> validateLocalProviders(AppData appData) async {
     try {
       // Try Ollama first (priority)
@@ -29,6 +29,16 @@ class ProviderValidator {
       
       if (llamaSuccess && llamaModels.isNotEmpty) {
         return AiProvider.llamacpp;
+      }
+
+      // Try llmman third
+      List<ModelItem> llmmanModels = [];
+      appData.setProvider(AiProvider.llmman);
+      await appData.api.loadSettings();
+      bool llmmanSuccess = await _canGetModels(appData, llmmanModels);
+
+      if (llmmanSuccess && llmmanModels.isNotEmpty) {
+        return AiProvider.llmman;
       }
     } catch (e) {
       if (kDebugMode) {

--- a/confichat/lib/ui_ollama_options.dart
+++ b/confichat/lib/ui_ollama_options.dart
@@ -15,7 +15,11 @@ import 'package:confichat/app_localizations.dart';
 class OllamaOptions extends StatefulWidget {
   final AppData appData;
 
-  const OllamaOptions({super.key, required this.appData});
+  // Reused by providers that speak the Ollama API on a different port (e.g. llmman)
+  final AiProvider provider;
+  final int defaultPort;
+
+  const OllamaOptions({super.key, required this.appData, this.provider = AiProvider.ollama, this.defaultPort = 11434});
 
   @override
   OllamaOptionsState createState() => OllamaOptionsState();
@@ -57,13 +61,13 @@ class OllamaOptionsState extends State<OllamaOptions> {
       final fileContent = await File(filePath).readAsString();
       final Map<String, dynamic> settings = json.decode(fileContent);
 
-      if (settings.containsKey(AiProvider.ollama.name) && AppData.instance.api.aiProvider.name ==  AiProvider.ollama.name) {
+      if (settings.containsKey(widget.provider.name) && AppData.instance.api.aiProvider.name ==  widget.provider.name) {
 
         // Set the form text
-        _schemeController.text = settings[AiProvider.ollama.name]['scheme'] ?? 'http';
-        _hostController.text = settings[AiProvider.ollama.name]['host'] ?? 'localhost';
-        _portController.text = settings[AiProvider.ollama.name]['port']?.toString() ?? '11434';
-        _pathController.text = settings[AiProvider.ollama.name]['path'] ?? '/api';
+        _schemeController.text = settings[widget.provider.name]['scheme'] ?? 'http';
+        _hostController.text = settings[widget.provider.name]['host'] ?? 'localhost';
+        _portController.text = settings[widget.provider.name]['port']?.toString() ?? widget.defaultPort.toString();
+        _pathController.text = settings[widget.provider.name]['path'] ?? '/api';
         _applySettings();
 
       } else {
@@ -77,17 +81,17 @@ class OllamaOptionsState extends State<OllamaOptions> {
   void _useDefaultSettings() {
     _schemeController.text = 'http';
     _hostController.text = '127.0.0.1';
-    _portController.text = '11434';
+    _portController.text = widget.defaultPort.toString();
     _pathController.text = '/api';
 
     _applySettings();
   }
 
   void _applySettings() {
-    if(widget.appData.api.aiProvider.name == AiProvider.ollama.name) { 
+    if(widget.appData.api.aiProvider.name == widget.provider.name) { 
       AppData.instance.api.scheme = _schemeController.text;
       AppData.instance.api.host = _hostController.text;
-      AppData.instance.api.port = int.tryParse(_portController.text) ?? 11434;
+      AppData.instance.api.port = int.tryParse(_portController.text) ?? widget.defaultPort;
       AppData.instance.api.path = _pathController.text;
     }
   }
@@ -99,7 +103,7 @@ class OllamaOptionsState extends State<OllamaOptions> {
     final newSetting = {
       'scheme': _schemeController.text,
       'host': _hostController.text,
-      'port': int.tryParse(_portController.text) ?? 11434,
+      'port': int.tryParse(_portController.text) ?? widget.defaultPort,
       'path': _pathController.text,
     };
 
@@ -110,13 +114,13 @@ class OllamaOptionsState extends State<OllamaOptions> {
       final content = await file.readAsString();
       settings = json.decode(content) as Map<String, dynamic>;
 
-      if (settings.containsKey(AiProvider.ollama.name)) {
-        settings[AiProvider.ollama.name] = newSetting;
+      if (settings.containsKey(widget.provider.name)) {
+        settings[widget.provider.name] = newSetting;
       } else {
-        settings[AiProvider.ollama.name] = newSetting;
+        settings[widget.provider.name] = newSetting;
       }
     } else {
-      settings = { AiProvider.ollama.name: newSetting };
+      settings = { widget.provider.name: newSetting };
     }
 
     // Set in-memory values
@@ -127,8 +131,8 @@ class OllamaOptionsState extends State<OllamaOptions> {
     await file.writeAsString(const JsonEncoder.withIndent(' ').convert(settings));
 
     // Reset model values
-     if(widget.appData.api.aiProvider.name == AiProvider.ollama.name) {
-      AppData.instance.callbackSwitchProvider(AiProvider.ollama);
+     if(widget.appData.api.aiProvider.name == widget.provider.name) {
+      AppData.instance.callbackSwitchProvider(widget.provider);
      }
 
     // Close window
@@ -153,7 +157,7 @@ class OllamaOptionsState extends State<OllamaOptions> {
             children: [
 
               // Window title
-              DialogTitle(title: loc.translate('providerOptions.title').replaceAll('{provider}', AiProvider.ollama.name)),
+              DialogTitle(title: loc.translate('providerOptions.title').replaceAll('{provider}', widget.provider.name)),
               const SizedBox(height: 24),
 
                 ConstrainedBox( constraints:  

--- a/confichat/lib/ui_provider_setup.dart
+++ b/confichat/lib/ui_provider_setup.dart
@@ -83,6 +83,12 @@ class ProviderSetupDialog extends StatelessWidget {
                       'https://github.com/ggerganov/llama.cpp',
                       Icons.terminal,
                     ),
+                    _buildProviderButton(
+                      context,
+                      'llmman',
+                      'https://github.com/llmmanorg/llmman',
+                      Icons.memory,
+                    ),
                   ],
                 ),
                 const SizedBox(height: 16),
@@ -160,7 +166,7 @@ class ProviderSetupManager {
     AppData appData,
     GlobalKey<ScaffoldState> scaffoldKey,  // Add scaffoldKey parameter
   ) async {
-    // (1) Check if Ollama or LlamaCPP can retrieve models
+    // (1) Check if Ollama, LlamaCPP or llmman can retrieve models
     AiProvider? localProvider = await ProviderValidator.validateLocalProviders(appData);
     if (localProvider != null) {
       return true;

--- a/confichat/lib/ui_sidebar.dart
+++ b/confichat/lib/ui_sidebar.dart
@@ -263,7 +263,21 @@ class SidebarState extends State<Sidebar> {
                       },
                     ),
 
-                    // (2.2.5) App settings
+                    // (2.2.5) llmman options (Ollama-compatible API on port 17434)
+                    ListTile(
+                      title: Text(AiProvider.llmman.name),
+                      onTap: () {
+                        showDialog(
+                          context: context,
+                          barrierDismissible: false,
+                          builder: (BuildContext context) {
+                            return OllamaOptions(appData: widget.appData, provider: AiProvider.llmman, defaultPort: 17434);
+                          },
+                        );
+                      },
+                    ),
+
+                    // (2.2.6) App settings
                     ListTile(
                       title: Text(loc.translate('sidebar.options.applicationSettings')),
                       onTap: () {

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -26,6 +26,11 @@ Get up and running with **ConfiChat** by following this guide. Whether you're us
    - [2. Run LlamaCpp Server](#2-run-llamacpp-server)
    - [3. Set Up ConfiChat](#3-set-up-confichat)
    - [Additional Resources](#additional-resources-3)
+5. [Using ConfiChat with llmman](#using-confichat-with-llmman)
+   - [1. Install llmman](#1-install-llmman)
+   - [2. Pull a Model and Start the Server](#2-pull-a-model-and-start-the-server)
+   - [3. Run ConfiChat](#3-run-confichat-3)
+   - [Additional Resources](#additional-resources-4)
 
 ---
 
@@ -179,3 +184,40 @@ Note: There may be a warning during first run as the binaries are unsigned.
 ### Additional Resources
 
 For more detailed instructions and troubleshooting, please visit the [LlamaCpp documentation](https://github.com/ggerganov/llama.cpp) and the [ConfiChat repository](https://github.com/your-repository/ConfiChat).
+
+---
+
+## Using ConfiChat with llmman
+
+[llmman](https://github.com/llmmanorg/llmman) is a local model runner that serves the Ollama API (alongside OpenAI- and Anthropic-compatible ones) on port 17434. Models are pulled as OCI artifacts or straight from Hugging Face and served by `llama.cpp`, `vllm` or `mlx-lm`.
+
+### 1. Install llmman
+
+- **macOS / Linux**:
+  ```bash
+  curl -fsSL https://raw.githubusercontent.com/llmmanorg/llmman/main/install.sh | sh
+  ```
+
+- **Windows** (PowerShell):
+  ```powershell
+  irm https://raw.githubusercontent.com/llmmanorg/llmman/main/install.ps1 | iex
+  ```
+
+### 2. Pull a Model and Start the Server
+
+```bash
+llmman pull gemma4
+llmman serve
+```
+
+The server listens on `http://localhost:17434` by default (override with the `LLMMAN_HOST` environment variable, e.g. `LLMMAN_HOST=0.0.0.0:17434`).
+
+### 3. Run ConfiChat
+
+1. Launch ConfiChat and select **llmman** from the provider dropdown.
+2. ConfiChat connects to `http://localhost:17434/api` by default. If you changed `LLMMAN_HOST`, open **Options > llmman** in the sidebar and update the host/port to match.
+3. Pick your model and start chatting.
+
+### Additional Resources
+
+For more detailed instructions and troubleshooting, please visit the [llmman repository](https://github.com/llmmanorg/llmman).


### PR DESCRIPTION
Adds [llmman](https://github.com/llmmanorg/llmman), a host-native local model runner that serves the Ollama API (plus OpenAI/Anthropic-compatible ones) on port 17434.

- `services/compose.llmman.yml` + `services/llmman/Caddyfile`: a `caddy:2-alpine` proxy on the harbor network forwarding to `HARBOR_LLMMAN_UPSTREAM_URL` (default `http://host.docker.internal:17434`), same pattern as `dmr`/`mlx`/`omlx`; `/health` backs the compose healthcheck.
- `profiles/default.env`: `HARBOR_LLMMAN_*` block (port `35080`, next free), incl. `HARBOR_LLMMAN_INTERNAL_URL` for cross-files.
- `compose.x.webui.llmman.yml` + `config.llmman.json`: register llmman as an Ollama connection in Open WebUI so `harbor up webui llmman` lists models from `llmman pull`.
- `serviceMetadata.ts` entry (org avatar as logo), `docs/2.2.27-Backend-llmman.md`, README backend list, one `.facts` entry.
- Host lifecycle (`harbor llmman start/pull`, `harbor launch`) intentionally not added; users run `llmman serve` themselves.

**Testing:** `harbor ls`/`harbor cmd webui llmman` resolve, compose `config` renders the service and mount, `harbor dev lint --compose --rules` clean, `caddy validate` OK, proxy verified against live `llmman serve` (`/health`, `/api/tags`, `/v1/models`), `tsc --noEmit` in `app/` exit 0, `.facts` passes.

> AI-assisted, reviewed before submitting.
